### PR TITLE
Fix flask server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       dockerfile: dockerfiles/Dockerfile.api
     ports:
-      - "5000:5000"
+      - "8000:8000"
   ui:
     build:
       dockerfile: dockerfiles/Dockerfile.ui

--- a/dockerfiles/Dockerfile.api
+++ b/dockerfiles/Dockerfile.api
@@ -4,4 +4,4 @@ COPY requirements/requirements-api.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY img_classification/api img_classification/api
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000 ", "img_classification.api.app:app"]
+ENTRYPOINT ["python3", "img_classification/api/app.py"]

--- a/dockerfiles/Dockerfile.ui
+++ b/dockerfiles/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8
 
 COPY requirements/requirements-ui.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/img_classification/api/app.py
+++ b/img_classification/api/app.py
@@ -4,6 +4,7 @@ from tensorflow.keras.preprocessing import image
 from PIL import Image
 import numpy as np
 import io
+import waitress
 
 app = Flask(__name__)
 
@@ -47,4 +48,4 @@ def predict():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    waitress.serve(app, host="0.0.0.0", port=8000)

--- a/img_classification/ui/app.py
+++ b/img_classification/ui/app.py
@@ -17,7 +17,7 @@ if uploaded_file is not None:
         # Access the uploaded image data
         image_data = uploaded_file.getvalue()
         response = requests.post(
-            'http://localhost:5000/predict',
+            'http://api:8000/predict',
             files={'file': ('image.png', image_data, 'multipart/form-data')}
         )
 

--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -1,5 +1,6 @@
 flask==2.1.2
-tensorflow==2.8.0
+Werkzeug==2.2.2
+tensorflow==2.13.1
 numpy==1.22.3
 pillow==9.1.0
-gunicorn==20.1.0
+waitress==3.0.0


### PR DESCRIPTION
# Changelog

- Change server provider to `waitress`, enforce `Werkzeug` dependency (otherwise `flask` fails to start`).
- Change API port to 8000 (port 5000 is often used by Docker registries).
- Update `tensorflow` version.
- Change base image for UI to `python:3.8` (slim version does not include `gcc` by `streamlit` dependencies).